### PR TITLE
use legacy lodash in node environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -808,7 +808,7 @@ if (typeof define == 'function' && typeof define.amd == 'object' &&
 } else if (typeof exports === 'object' && !exports.nodeType) {
   // Node
   var assert = factory(
-    require('lodash')
+    require('lodash/dist/lodash.legacy')
   );
 
   module.exports = assert;


### PR DESCRIPTION
Using normal lodash will fail some tests in IE if the user is using
goinstant-assert within browserify.  This happens because if the tests
are built with browserify, lodash will be included via a `require` call,
rather than reading lodash off of the window.
