### PR TITLE
Update to lodash 4.5.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,13 +259,13 @@ assert.notInstanceOf = function(value, constructor, message) {
 };
 
 assert.include = function(haystack, needle, message) {
-  if (!_.include(haystack, needle)) {
+  if (!_.includes(haystack, needle)) {
     fail(haystack, "to include", needle, message, assert.include);
   }
 };
 
 assert.notInclude = function(haystack, needle, message) {
-  if (_.include(haystack, needle)) {
+  if (_.includes(haystack, needle)) {
     fail(haystack, "to not include", needle, message, assert.notInclude);
   }
 };
@@ -437,7 +437,7 @@ var objectDisplay = function (obj) {
   var str = inspect(obj);
   var type = Object.prototype.toString.call(obj);
 
-  if (str.length >= 40) {
+  if (str.length >= 250) {
     if (type === '[object Function]') {
       return !obj.name || obj.name === '' ? '[Function]'
         : '[Function: ' + obj.name + ']';
@@ -452,7 +452,7 @@ var objectDisplay = function (obj) {
       return str;
     }
   } else {
-    return str;
+    return JSON.strinfify(obj, null, 4);
   }
 };
 
@@ -808,7 +808,7 @@ if (typeof define == 'function' && typeof define.amd == 'object' &&
 } else if (typeof exports === 'object' && !exports.nodeType) {
   // Node
   var assert = factory(
-    require('lodash/dist/lodash.legacy')
+    require('lodash')
   );
 
   module.exports = assert;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goinstant-assert",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "GoInstant <support@goinstant.com> (http://www.goinstant.com)",
   "description": "Cross-browser/node Assertions Library that runs in legacy browsers.",
   "main": "index.js",
@@ -21,7 +21,7 @@
     "blanket": "~1.1.5"
   },
   "dependencies": {
-    "lodash": "1.3.1"
+    "lodash": "4.5.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Lodash is wayyy out of date here and its causing issues with deep comparison of relatively simple objects.
- Update lodash to 4.5.1
- Fix two references to include which is now includes.
- Fix output of objects on failed deepEquals

```
npm test

> goinstant-assert@1.1.3 test /Users/pcyr/repos/assert
> mocha test/test.js


․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

109 tests complete (23 ms)
```

@colinmacdonald 
